### PR TITLE
Fix modrinth api token-less builds

### DIFF
--- a/neoforge.gradle
+++ b/neoforge.gradle
@@ -131,7 +131,7 @@ curseforge {
 tasks.getByName("curseforge").mustRunAfter build
 
 modrinth {
-    token = findProperty('modrinthApiToken') ?: 0
+    token = findProperty('modrinthApiToken') ?: '0'
     projectId = "${modrinth_id}"
     versionNumber = version
     versionName = remapJar.archiveFileName


### PR DESCRIPTION
Having modrinth token fallback to integer impedes regular builds